### PR TITLE
Use GMAIL_USER for nodemailer and add config example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Environment variables for email sending
+GMAIL_USER=your.email@example.com
+GMAIL_APP_PASSWORD=your_app_password

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/app/api/sendMail/route.tsx
+++ b/app/api/sendMail/route.tsx
@@ -4,12 +4,14 @@ import nodemailer from 'nodemailer'
 export async function POST(request: NextRequest) {
   const { name, email, message } = await request.json()
 
+  const gmailUser = process.env.GMAIL_USER
+
   const transporter = nodemailer.createTransport({
     host: "smtp.gmail.com",
     port: 465,
     secure: true,
     auth: {
-      user: "scaramuzzohnb@gmail.com",
+      user: gmailUser,
       pass: process.env.GMAIL_APP_PASSWORD // Usa la variabile d'ambiente
     }
   })
@@ -17,7 +19,7 @@ export async function POST(request: NextRequest) {
   try {
     await transporter.sendMail({
       from: `"${name}" <${email}>`,
-      to: "scaramuzzohnb@gmail.com",
+      to: gmailUser,
       subject: "Nuovo messaggio dal form di contatto",
       text: `Nome: ${name}\nEmail: ${email}\nMessaggio: ${message}`,
       html: `<p><strong>Nome:</strong> ${name}</p>


### PR DESCRIPTION
## Summary
- read Gmail credentials from GMAIL_USER env var
- document GMAIL_USER and GMAIL_APP_PASSWORD in example env file

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5bdb903b883338929bdc71960dc78