### PR TITLE
Centralize translations across app

### DIFF
--- a/app/components/About.tsx
+++ b/app/components/About.tsx
@@ -1,23 +1,13 @@
 import { FC } from 'react'
 import Image from 'next/image'
+import { aboutTranslations } from '@/lib/translations'
 
 interface AboutProps {
   language: 'it' | 'en'
 }
 
 const About: FC<AboutProps> = ({ language }) => {
-  const translations = {
-    it: {
-      title: "Chi Siamo",
-      description:
-        "Scaramuzzo Hair Natural Beauty è un salone di bellezza all'avanguardia che combina tecniche tradizionali con le ultime innovazioni nel campo della cura dei capelli. Fondato da Giuseppe Scaramuzzo, il nostro salone si impegna a offrire servizi personalizzati e prodotti naturali per esaltare la bellezza unica di ogni cliente. Con anni di esperienza e una passione per l'eccellenza, il nostro team di stilisti altamente qualificati si dedica a creare look che riflettono la personalità e lo stile di vita di ciascun individuo. Utilizziamo solo prodotti di alta qualità e rispettosi dell'ambiente, garantendo risultati straordinari e capelli sani. Venite a scoprire l'esperienza Scaramuzzo, dove la bellezza naturale incontra l'arte del parrucchiere.",
-    },
-    en: {
-      title: "About Us",
-      description:
-        "Scaramuzzo Hair Natural Beauty is a cutting-edge beauty salon that combines traditional techniques with the latest innovations in hair care. Founded by Giuseppe Scaramuzzo, our salon is committed to offering personalized services and natural products to enhance the unique beauty of each client. With years of experience and a passion for excellence, our team of highly skilled stylists is dedicated to creating looks that reflect the personality and lifestyle of each individual. We use only high-quality, environmentally friendly products, ensuring extraordinary results and healthy hair. Come and discover the Scaramuzzo experience, where natural beauty meets the art of hairdressing.",
-    },
-  }
+  const translations = aboutTranslations
 
   return (
     <section className="relative py-16 sm:py-20 md:py-24 lg:py-32 bg-background text-white">

--- a/app/components/Contact.tsx
+++ b/app/components/Contact.tsx
@@ -1,37 +1,17 @@
-'use client'
+"use client"
 
 import { FC, useState } from 'react'
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
+import { contactTranslations } from "@/lib/translations"
 
 interface ContactProps {
   language: 'it' | 'en'
 }
 
 const Contact: FC<ContactProps> = ({ language }) => {
-  const translations = {
-    it: {
-      title: "Contattaci",
-      name: "Nome",
-      email: "Email",
-      message: "Messaggio",
-      send: "Invia",
-      sending: "Inviando...",
-      success: "Messaggio inviato con successo!",
-      error: "Si è verificato un errore nell'invio del messaggio."
-    },
-    en: {
-      title: "Contact Us",
-      name: "Name",
-      email: "Email",
-      message: "Message",
-      send: "Send",
-      sending: "Sending...",
-      success: "Message sent successfully!",
-      error: "An error occurred while sending the message."
-    },
-  }
+  const translations = contactTranslations
 
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')

--- a/app/components/Home.tsx
+++ b/app/components/Home.tsx
@@ -1,21 +1,13 @@
 import { FC } from 'react'
 import Image from 'next/image'
+import { homeTranslations } from '@/lib/translations'
 
 interface HomeProps {
   language: 'it' | 'en'
 }
 
 const Home: FC<HomeProps> = ({ language }) => {
-  const translations = {
-    it: {
-      hero: "Il tuo stile, naturalmente perfetto",
-      description: "Trasformiamo i tuoi capelli con cura naturale",
-    },
-    en: {
-      hero: "Your style, naturally perfect",
-      description: "We transform your hair with natural care",
-    },
-  }
+  const translations = homeTranslations
 
   return (
     <section className="relative h-[60vh] md:h-[80vh] lg:h-screen flex items-center justify-center overflow-hidden">

--- a/app/components/Products.tsx
+++ b/app/components/Products.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client"
 
 import { FC } from "react";
 import {
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/card";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { productsTranslations } from "@/lib/translations";
 
 interface ProductsProps {
   language: "it" | "en";
@@ -18,88 +19,7 @@ interface ProductsProps {
 const Products: FC<ProductsProps> = ({ language }) => {
   const router = useRouter();
 
-  const translations = {
-    it: {
-      title: "I Nostri Prodotti",
-      products: [
-        {
-          id: "shampoo-riflessante-henne",
-          name: "Shampoo Riflessante con Henné",
-          description: "Mantiene i riflessi naturali dei capelli trattati con henné.",
-          image: "/sh-hennè.webp",
-          imageAlt: "Shampoo Riflessante con Henné",
-        },
-        {
-          id: "maschera-riflessante-henne",
-          name: "Maschera Riflessante con Henné",
-          description: "Nutre e ravviva il colore naturalmente.",
-          image: "/mask-hennè.webp",
-          imageAlt: "Maschera Riflessante con Henné",
-        },
-        {
-          id: "Shampoo-Purificante-seboregolatore",
-          name: "Shampoo Purificante-Seboregolatore",
-          description: "Azione riequilibrante per cute grassa o sensibile.",
-          image: "/sh-hennè.webp",
-          imageAlt: "Shampoo Purificante",
-        },
-        {
-          id: "Bagnoschiuma-Purificante",
-          name: "Bagnoschiuma Purificante",
-          description: "Sensazione di freschezza e pulizia profonda.",
-          image: "/sh-hennè.webp",
-          imageAlt: "Bagnoschiuma",
-        },
-        {
-          id: "Olio-lenitivo-olivo-e-girasole",
-          name: "Olio Lenitivo Olivo & Girasole",
-          description: "Idratazione intensa e naturale.",
-          image: "/sh-hennè.webp",
-          imageAlt: "Olio Lenitivo",
-        },
-      ],
-    },
-    en: {
-      title: "Our Products",
-      products: [
-        {
-          id: "reflective-henna-shampoo",
-          name: "Reflective Shampoo with Henna",
-          description: "Enhances and maintains henna-treated hair tones.",
-          image: "/sh-hennè.webp",
-          imageAlt: "Reflective Shampoo",
-        },
-        {
-          id: "reflective-henna-mask",
-          name: "Reflective Mask with Henna",
-          description: "Deeply nourishes and enhances reflections.",
-          image: "/mask-hennè.webp",
-          imageAlt: "Reflective Mask",
-        },
-        {
-          id: "hair-oil",
-          name: "Purifying Shampoo",
-          description: "Sebum-balancing formula for a clean scalp.",
-          image: "/sh-hennè.webp",
-          imageAlt: "Purifying Shampoo",
-        },
-        {
-          id: "hydrating-bodywash",
-          name: "Purifying Bodywash",
-          description: "Deep cleansing and fresh sensation.",
-          image: "/sh-hennè.webp",
-          imageAlt: "Bodywash",
-        },
-        {
-          id: "soothing-oil",
-          name: "Soothing Oil - Olive & Sunflower",
-          description: "Moisturizing and softening treatment.",
-          image: "/sh-hennè.webp",
-          imageAlt: "Soothing Oil",
-        },
-      ],
-    },
-  };
+  const translations = productsTranslations;
 
   const handleProductClick = (id: string) => {
     router.push(`/products/${id}`);

--- a/app/components/Services.tsx
+++ b/app/components/Services.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client"
 
 import { FC } from "react";
 import {
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/card";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { servicesTranslations } from "@/lib/translations";
 
 interface ServicesProps {
   language: "it" | "en";
@@ -18,102 +19,7 @@ interface ServicesProps {
 const Services: FC<ServicesProps> = ({ language }) => {
   const router = useRouter();
 
-  const translations = {
-    it: {
-      title: "I Nostri Servizi",
-      services: [
-        {
-          id: "taglio-di-capelli",
-          name: "Taglio di Capelli",
-          description: "Taglio personalizzato per uomo e donna",
-          image: "/TaglioNew.jpg",
-          imageAlt: "Taglio di Capelli",
-        },
-        {
-          id: "colorazione-con-erbe-botaniche",
-          name: "Colorazione con erbe botaniche",
-          description: "Tinte naturali e tecniche innovative",
-          image: "/ERBE.jpg",
-          imageAlt: "Colorazione con erbe botaniche",
-        },
-        {
-          id: "trattamenti",
-          name: "Trattamenti",
-          description: "Trattamenti per capelli danneggiati e cure specifiche",
-          image: "/trattamento.jpg",
-          imageAlt: "Trattamenti",
-        },
-        {
-          id: "acconciature",
-          name: "Acconciature",
-          description: "Styling per ogni occasione",
-          image: "/Acconciatura.jpg",
-          imageAlt: "Acconciature",
-        },
-        {
-          id: "sanlai",
-          name: "Sanlai",
-          description: "Schiariture naturali e luminose",
-          image: "/sanlai.webp",
-          imageAlt: "Schiariture Sanlai",
-        },
-        {
-          id: "massaggio-del-cuoio-capelluto",
-          name: "Massaggio del Cuoio Capelluto",
-          description: "Rilassante massaggio per la salute dei capelli",
-          image: "/Massaggio.webp",
-          imageAlt: "Massaggio del Cuoio Capelluto",
-        },
-      ],
-    },
-    en: {
-      title: "Our Services",
-      services: [
-        {
-          id: "haircut",
-          name: "Haircut",
-          description: "Personalized cut for men and women",
-          image: "/TaglioNew.jpg",
-          imageAlt: "Haircut",
-        },
-        {
-          id: "botanical-hair-coloring",
-          name: "Botanical Hair Coloring",
-          description: "Natural dyes and innovative techniques",
-          image: "/ERBE.jpg",
-          imageAlt: "Botanical Hair Coloring",
-        },
-        {
-          id: "treatments",
-          name: "Treatments",
-          description: "Treatments for damaged hair and specific care",
-          image: "/trattamento.jpg",
-          imageAlt: "Treatments",
-        },
-        {
-          id: "hairstyling",
-          name: "Hairstyling",
-          description: "Styling for every occasion",
-          image: "/Acconciatura.jpg",
-          imageAlt: "Hairstyling",
-        },
-        {
-          id: "sanlai",
-          name: "Sanlai",
-          description: "Natural and bright highlights",
-          image: "/sanlai.webp",
-          imageAlt: "Sanlai Highlights",
-        },
-        {
-          id: "scalp-massage",
-          name: "Scalp Massage",
-          description: "Relaxing massage for hair health",
-          image: "/Massaggio.webp",
-          imageAlt: "Scalp Massage",
-        },
-      ],
-    },
-  };
+  const translations = servicesTranslations;
 
   const handleServiceClick = (id: string) => {
     router.push(`/services/${id}`);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,26 +16,7 @@ import About from "@/app/components/About"
 import Services from "@/app/components/Services"
 import Products from "@/app/components/Products"
 import Contact from "@/app/components/Contact"
-
-type Language = 'it' | 'en'
-type PageKey = 'home' | 'about' | 'services' | 'products' | 'contact'
-
-const translations: Record<Language, Record<PageKey, string>> = {
-  it: {
-    home: "Home",
-    about: "Chi Siamo",
-    services: "Servizi",
-    products: "Prodotti",
-    contact: "Contatti",
-  },
-  en: {
-    home: "Home",
-    about: "About Us",
-    services: "Services",
-    products: "Products",
-    contact: "Contact",
-  }
-}
+import { navbarTranslations, Language, PageKey } from "@/lib/translations"
 
 export default function Page() {
   const [theme, setTheme] = useState<"light" | "dark">("light")
@@ -69,7 +50,7 @@ export default function Page() {
 
   const NavItems = () => (
     <>
-      {(Object.keys(translations[language]) as PageKey[]).map((key) => (
+      {(Object.keys(navbarTranslations[language]) as PageKey[]).map((key) => (
         <Button
           key={key}
           variant="ghost"
@@ -79,7 +60,7 @@ export default function Page() {
           }}
           className={`transition-all hover:text-primary font-semibold text-lg ${currentPage === key ? "text-primary" : ""}`}
         >
-          {translations[language][key]}
+          {navbarTranslations[language][key]}
         </Button>
       ))}
     </>

--- a/app/products/[id]/page.tsx
+++ b/app/products/[id]/page.tsx
@@ -1,89 +1,17 @@
-'use client'
+"use client"
 
 import { FC, useEffect, useState, useCallback } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import Image from 'next/image'
 import { Button } from "@/components/ui/button"
-
-interface Product {
-  id: string
-  name: string
-  description: string
-  image: string
-  detailedDescription: string
-}
-
-interface Translations {
-  [key: string]: {
-    products: Product[]
-  }
-}
+import { productsTranslations, Product } from "@/lib/translations"
 
 const ProductPage: FC = () => {
   const params = useParams()
   const router = useRouter()
   const [language, setLanguage] = useState<'it' | 'en'>('it')
   const [product, setProduct] = useState<Product | null>(null)
-
-  const translations: Translations = {
-    it: {
-      products: [
-        {
-          id: "shampoo-riflessante-henne",
-          name: "Shampoo Riflessante con estratto di hennè",
-          description: "Formula riflessante per mantenere i toni spettacolari dell'hennè.",
-          image: "/sh-hennè.webp",
-          detailedDescription:" Formula riflessante per mantenere i toni spettacolari dell'hennè. Un prodotto unico formulato con puro estratto di hennè, ricco di zuccheri che ristrutturano la fibra capillare donando nuova vitalità. MODO D'USO A capello bagnato applicare il prodotto, massaggiare, lasciare agire per 4 minuti e procedere al risciacquo.PRINCIPI ATTIVILawsonia inermis leaves extract, Zuccheri.AZIONI Protegge e ristruttura in profondità la fibra capillare per dare elasticità e idratazione.PUNTI DI FORZALe erbe botaniche rappresentano uno dei prodotti base della fitocosmesi, ricavato dalle foglie essiccate e polverizzate di un arbusto (Lawsonia inermis) comunemente chiamato henna. La formula miscelata con estratti di erbe botaniche, rende il prodotto ottimale nel creare riflessi particolari, migliorando la lucentezza dei colori applicati e la morbidezza del capello. Le basi detergenti, dolci e delicate, consentono di utilizzare il prodotto su qualsiasi tipo di capello senza impoverirne il manto idrolipidico.INGREDIENTILawsonia inermis leaves extract, Sodium coceth sulfate, Cocamido propyl betaine, Cetrimonium chloride, Polyquaterniurn 10, Parfurn, Phenoxy ethanol, Sodiurn chloride. PARABENS FREE - SILICONES FREE"
-        },
-        {
-          id: "maschera-riflessante-henne",
-          name: "Maschera riflessante con estratto di hennè",
-          description: "Un prodotto unico formulato con puro estratto di hennè, ricco di zuccheri che ristrutturano la fibra capillare donando nuova vitalità.",
-          image: "/mask-hennè.webp",
-          detailedDescription: "La Maschera riflessante con estratto di hennè è un trattamento intensivo che combina le proprietà nutrienti e ristrutturanti dell'hennè con una formula ricca di principi attivi. Il puro estratto di hennè, ricco di zuccheri naturali, penetra in profondità nella fibra capillare, riparandola e rinforzandola dall'interno. Questo trattamento non solo mantiene vivaci i riflessi, ma migliora anche la struttura del capello, lasciandolo più forte, elastico e luminoso.",
-        },
-        {
-        id: "Shampoo-Purificante-seboregolatore",
-        name: "Shampoo Purificante-seboregolatore",
-        description: "Olio leggero per capelli lucenti",
-        image: "/sh-hennè.webp",
-        detailedDescription: "Il nostro Olio per Capelli è una formula leggera ma potente, studiata per nutrire in profondità i capelli senza appesantirli. Arricchito con oli naturali selezionati, questo prodotto aiuta a combattere il crespo, aumenta la lucentezza e protegge i capelli dai danni ambientali. Perfetto per tutti i tipi di capelli, può essere utilizzato sia come trattamento pre-shampoo che come finish per domare i capelli ribelli."},
-        {
-          id: "Bagnoschiuma-Purificante",
-          name: "Bagnoschiuma-Purificante",
-          description: "Bagnoschiuma-Purificante",
-          image: "/sh-hennè.webp",
-          detailedDescription: "Azione antibatterica grazie all'estratto di liquirizia, bergamotto, ortica, cedro che dona alla pelle un'eccezionale sensazione di pulizia e freschezza.Azione calmante e lenitiva grazie all'utilizzo dell'acqua termale",
-        },
-        {
-          id: "Olio-lenitivo-olivo-e-girasole",
-          name: "Olio lenitivo olivo e girasole",
-          description: "Azione lenitiva intensa",
-          image: "/sh-hennè.webp",
-          detailedDescription: "Formulato con puri oli di girasole e oliva, per un'idratazione emolliente intensad",
-        },
-      ],
-    },
-    en: {
-      products: [
-        {
-          id: "reflective-henna-shampoo",
-          name: "Reflective Shampoo with henna extract",
-          description: "Reflective formula to maintain spectacular henna tones.",
-          image: "/sh-hennè.webp",
-          detailedDescription: "The Reflective Shampoo with henna extract has been specially formulated to maintain and enhance the reflections of henna-treated hair. Its gentle formula, enriched with natural extracts, not only gently cleanses the hair but also helps preserve the brilliance and intensity of the color. Ideal for frequent use, this shampoo nourishes and protects hair, leaving it soft, luminous, and with vibrant reflections.",
-        },
-        {
-          id: "reflective-henna-mask",
-          name: "Reflective mask with henna extract",
-          description: "A unique product formulated with pure henna extract, rich in sugars that restructure the hair fiber giving new vitality.",
-          image: "/mask-hennè.webp",
-          detailedDescription: "The Reflective mask with henna extract is an intensive treatment that combines the nourishing and restructuring properties of henna with a formula rich in active ingredients. Pure henna extract, rich in natural sugars, penetrates deep into the hair fiber, repairing and strengthening it from within. This treatment not only keeps reflections vibrant but also improves hair structure, leaving it stronger, more elastic, and luminous.",
-        },
-        // Aggiungi altri prodotti qui...
-      ],
-    },
-  }
+  const translations = productsTranslations
 
   useEffect(() => {
     const storedLanguage = localStorage.getItem('language') as 'it' | 'en'
@@ -94,50 +22,41 @@ const ProductPage: FC = () => {
 
   useEffect(() => {
     if (params.id) {
-      const currentProduct = translations[language].products.find(p => p.id === params.id)
-      if (currentProduct) {
-        setProduct(currentProduct)
-      } else {
-        // Se non trovato nella lingua corrente, prova a trovare il prodotto corrispondente nell'altra lingua
+      let currentProduct = translations[language].products.find(p => p.id === params.id)
+
+      if (!currentProduct) {
         const otherLanguage = language === 'it' ? 'en' : 'it'
-        const matchingProduct = translations[otherLanguage].products.find(p => p.id === params.id)
-        if (matchingProduct) {
-          const correspondingProduct = translations[language].products.find(p => 
-            (language === 'it' && p.id === 'shampoo-riflessante-henne' && matchingProduct.id === 'reflective-henna-shampoo') ||
-            (language === 'it' && p.id === 'maschera-riflessante-henne' && matchingProduct.id === 'reflective-henna-mask') ||
-            (language === 'en' && p.id === 'reflective-henna-shampoo' && matchingProduct.id === 'shampoo-riflessante-henne') ||
-            (language === 'en' && p.id === 'reflective-henna-mask' && matchingProduct.id === 'maschera-riflessante-henne')
-          )
-          if (correspondingProduct) {
-            setProduct(correspondingProduct)
-          }
+        const productInOtherLanguage = translations[otherLanguage].products.find(p => p.id === params.id)
+        if (productInOtherLanguage) {
+          currentProduct = translations[language].products.find(p => p.alias === productInOtherLanguage.id)
         }
       }
+
+      setProduct(currentProduct || null)
     }
-  }, [params.id, language])
+  }, [params.id, language, translations])
 
   const handleBackClick = useCallback(() => {
-    router.push('/')  // adesso torni alla home
+    router.push('/')
     localStorage.setItem('navigateTo', 'products')
   }, [router])
-  
 
   useEffect(() => {
     const navigateTo = localStorage.getItem('navigateTo')
     if (navigateTo === 'products') {
       const timer = setTimeout(() => {
-        const buttons = document.querySelectorAll('button');
-        const productsButton = Array.from(buttons).find(button => 
+        const buttons = document.querySelectorAll('button')
+        const productsButton = Array.from(buttons).find(button =>
           button.textContent === 'Prodotti' || button.textContent === 'Products'
-        ) as HTMLButtonElement | undefined;
-        
+        ) as HTMLButtonElement | undefined
+
         if (productsButton) {
-          productsButton.click();
+          productsButton.click()
         }
         localStorage.removeItem('navigateTo')
-      }, 100);
+      }, 100)
 
-      return () => clearTimeout(timer);
+      return () => clearTimeout(timer)
     }
   }, [])
 

--- a/app/services/[id]/page.tsx
+++ b/app/services/[id]/page.tsx
@@ -1,159 +1,17 @@
-'use client'
+"use client"
 
 import { FC, useEffect, useState, useCallback } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import Image from 'next/image'
 import { Button } from "@/components/ui/button"
-
-interface Service {
-  id: string
-  alias?: string
-  name: string
-  description: string
-  image: string
-  imageAlt: string
-  detailedDescription: string
-}
-
-// Definisci translations fuori dal componente se vuoi evitare warning sui useEffect
-const translations = {
-  it: {
-    services: [
-      {
-        id: "taglio-di-capelli",
-        alias: "haircut",
-        name: "Taglio di Capelli",
-        description: "Taglio personalizzato per uomo e donna",
-        image: "/taglio.jpg",
-        imageAlt: "Taglio di Capelli",
-        detailedDescription: "Il nostro servizio di taglio capelli offre un'esperienza personalizzata per ogni cliente. ...",
-      },
-      {
-        id: "colorazione-con-erbe-botaniche",
-        alias: "botanical-hair-coloring",
-        name: "Colorazione con erbe botaniche",
-        description: "Tinte naturali e tecniche innovative",
-        image: "/ERBE.jpg",
-        imageAlt: "Colorazione con erbe botaniche",
-        detailedDescription: "La nostra colorazione con erbe botaniche è un trattamento delicato e naturale ...",
-      },
-      {
-        id: "trattamenti",
-        alias: "treatments",
-        name: "Trattamenti",
-        description: "Trattamenti per capelli danneggiati e cure specifiche",
-        image: "/trattamento.jpg",
-        imageAlt: "Trattamenti",
-        detailedDescription: 
-`Offriamo una vasta gamma di trattamenti per capelli:
-- Cheratina Vegetale: ...
-- Trattamenti Cute con Erbe: ...
-- Peeling: ...
-- Rigenerante: ...
-- Post Colore: ...
-- Trattamento di Rigenerazione: ...`,
-      },
-      {
-        id: "acconciature",
-        alias: "hairstyling",
-        name: "Acconciature",
-        description: "Styling per ogni occasione",
-        image: "/erbe.jpg",
-        imageAlt: "Acconciature",
-        detailedDescription: "Che si tratti di un'occasione speciale o di un look quotidiano, ...",
-      },
-      {
-        id: "sanlai",
-        alias: "sanlai",
-        name: "Sanlai",
-        description: "Schiariture",
-        image: "/sanlai.webp",
-        imageAlt: "Schiariture Sanlai",
-        detailedDescription: "La tecnica Sanlai è il nostro metodo innovativo per schiarire i capelli ...",
-      },
-      {
-        id: "massaggio-del-cuoio-capelluto",
-        alias: "scalp-massage",
-        name: "Massaggio del Cuoio Capelluto",
-        description: "Rilassante massaggio per la salute dei capelli",
-        image: "/Massaggio.webp",
-        imageAlt: "Massaggio del Cuoio Capelluto",
-        detailedDescription: "Il nostro massaggio del cuoio capelluto non è solo rilassante, ma anche benefico ...",
-      },
-    ],
-  },
-  en: {
-    services: [
-      {
-        id: "taglio-di-capelli",
-        alias: "taglio-di-capelli",
-        name: "Haircut",
-        description: "Personalized cut for men and women",
-        image: "/taglio.jpg",
-        imageAlt: "Haircut",
-        detailedDescription: "Our haircut service offers a personalized experience ...",
-      },
-      {
-        id: "botanical-hair-coloring",
-        alias: "colorazione-con-erbe-botaniche",
-        name: "Botanical Hair Coloring",
-        description: "Natural dyes and innovative techniques",
-        image: "/erbe.jpg",
-        imageAlt: "Botanical Hair Coloring",
-        detailedDescription: "Our botanical hair coloring is a gentle and natural treatment ...",
-      },
-      {
-        id: "treatments",
-        alias: "trattamenti",
-        name: "Treatments",
-        description: "Treatments for damaged hair and specific care",
-        image: "/erbe.jpg",
-        imageAlt: "Treatments",
-        detailedDescription:
-`We offer a wide range of treatments for hair:
-- Plant-Based Keratin: ...
-- Herbal Scalp Treatments: ...
-- Peeling: ...
-- Revitalizing: ...
-- Post Color: ...
-- Deep Regeneration Treatment: ...`,
-      },
-      {
-        id: "hairstyling",
-        alias: "acconciature",
-        name: "Hairstyling",
-        description: "Styling for every occasion",
-        image: "/erbe.jpg",
-        imageAlt: "Hairstyling",
-        detailedDescription: "Whether it's for a special occasion or an everyday look, ...",
-      },
-      {
-        id: "sanlai",
-        alias: "sanlai",
-        name: "Sanlai",
-        description: "Hair lightening",
-        image: "/sanlai.webp",
-        imageAlt: "Sanlai Hair Lightening",
-        detailedDescription: "The Sanlai technique is our innovative method for lightening hair ...",
-      },
-      {
-        id: "scalp-massage",
-        alias: "massaggio-del-cuoio-capelluto",
-        name: "Scalp Massage",
-        description: "Relaxing massage for hair health",
-        image: "/erbe.jpg",
-        imageAlt: "Scalp Massage",
-        detailedDescription: "Our scalp massage is not only relaxing but also beneficial ...",
-      },
-    ],
-  },
-};
+import { servicesTranslations, Service } from "@/lib/translations"
 
 const ServicePage: FC = () => {
   const params = useParams()
   const router = useRouter()
   const [language, setLanguage] = useState<'it' | 'en'>('it')
   const [service, setService] = useState<Service | null>(null)
+  const translations = servicesTranslations
 
   useEffect(() => {
     const storedLanguage = localStorage.getItem('language') as 'it' | 'en'
@@ -176,7 +34,7 @@ const ServicePage: FC = () => {
 
       setService(currentService || null);
     }
-  }, [params.id, language])
+  }, [params.id, language, translations])
 
   const handleBackClick = useCallback(() => {
     // Torna alla home

--- a/lib/translations.ts
+++ b/lib/translations.ts
@@ -1,0 +1,323 @@
+export type Language = 'it' | 'en'
+export type PageKey = 'home' | 'about' | 'services' | 'products' | 'contact'
+
+export const navbarTranslations: Record<Language, Record<PageKey, string>> = {
+  it: {
+    home: "Home",
+    about: "Chi Siamo",
+    services: "Servizi",
+    products: "Prodotti",
+    contact: "Contatti",
+  },
+  en: {
+    home: "Home",
+    about: "About Us",
+    services: "Services",
+    products: "Products",
+    contact: "Contact",
+  },
+}
+
+export const homeTranslations = {
+  it: {
+    hero: "Il tuo stile, naturalmente perfetto",
+    description: "Trasformiamo i tuoi capelli con cura naturale",
+  },
+  en: {
+    hero: "Your style, naturally perfect",
+    description: "We transform your hair with natural care",
+  },
+}
+
+export const aboutTranslations = {
+  it: {
+    title: "Chi Siamo",
+    description:
+      "Scaramuzzo Hair Natural Beauty è un salone di bellezza all'avanguardia che combina tecniche tradizionali con le ultime innovazioni nel campo della cura dei capelli. Fondato da Giuseppe Scaramuzzo, il nostro salone si impegna a offrire servizi personalizzati e prodotti naturali per esaltare la bellezza unica di ogni cliente. Con anni di esperienza e una passione per l'eccellenza, il nostro team di stilisti altamente qualificati si dedica a creare look che riflettono la personalità e lo stile di vita di ciascun individuo. Utilizziamo solo prodotti di alta qualità e rispettosi dell'ambiente, garantendo risultati straordinari e capelli sani. Venite a scoprire l'esperienza Scaramuzzo, dove la bellezza naturale incontra l'arte del parrucchiere.",
+  },
+  en: {
+    title: "About Us",
+    description:
+      "Scaramuzzo Hair Natural Beauty is a cutting-edge beauty salon that combines traditional techniques with the latest innovations in hair care. Founded by Giuseppe Scaramuzzo, our salon is committed to offering personalized services and natural products to enhance the unique beauty of each client. With years of experience and a passion for excellence, our team of highly skilled stylists is dedicated to creating looks that reflect the personality and lifestyle of each individual. We use only high-quality, environmentally friendly products, ensuring extraordinary results and healthy hair. Come and discover the Scaramuzzo experience, where natural beauty meets the art of hairdressing.",
+  },
+}
+
+export const contactTranslations = {
+  it: {
+    title: "Contattaci",
+    name: "Nome",
+    email: "Email",
+    message: "Messaggio",
+    send: "Invia",
+    sending: "Inviando...",
+    success: "Messaggio inviato con successo!",
+    error: "Si è verificato un errore nell'invio del messaggio.",
+  },
+  en: {
+    title: "Contact Us",
+    name: "Name",
+    email: "Email",
+    message: "Message",
+    send: "Send",
+    sending: "Sending...",
+    success: "Message sent successfully!",
+    error: "An error occurred while sending the message.",
+  },
+}
+
+export interface Service {
+  id: string
+  alias?: string
+  name: string
+  description: string
+  image: string
+  imageAlt: string
+  detailedDescription: string
+}
+
+export const servicesTranslations: Record<Language, { title: string; services: Service[] }> = {
+  it: {
+    title: "I Nostri Servizi",
+    services: [
+      {
+        id: "taglio-di-capelli",
+        alias: "haircut",
+        name: "Taglio di Capelli",
+        description: "Taglio personalizzato per uomo e donna",
+        image: "/TaglioNew.jpg",
+        imageAlt: "Taglio di Capelli",
+        detailedDescription: "Il nostro servizio di taglio capelli offre un'esperienza personalizzata per ogni cliente. ...",
+      },
+      {
+        id: "colorazione-con-erbe-botaniche",
+        alias: "botanical-hair-coloring",
+        name: "Colorazione con erbe botaniche",
+        description: "Tinte naturali e tecniche innovative",
+        image: "/ERBE.jpg",
+        imageAlt: "Colorazione con erbe botaniche",
+        detailedDescription: "La nostra colorazione con erbe botaniche è un trattamento delicato e naturale ...",
+      },
+      {
+        id: "trattamenti",
+        alias: "treatments",
+        name: "Trattamenti",
+        description: "Trattamenti per capelli danneggiati e cure specifiche",
+        image: "/trattamento.jpg",
+        imageAlt: "Trattamenti",
+        detailedDescription: `Offriamo una vasta gamma di trattamenti per capelli:
+- Cheratina Vegetale: ...
+- Trattamenti Cute con Erbe: ...
+- Peeling: ...
+- Rigenerante: ...
+- Post Colore: ...
+- Trattamento di Rigenerazione: ...`,
+      },
+      {
+        id: "acconciature",
+        alias: "hairstyling",
+        name: "Acconciature",
+        description: "Styling per ogni occasione",
+        image: "/Acconciatura.jpg",
+        imageAlt: "Acconciature",
+        detailedDescription: "Che si tratti di un'occasione speciale o di un look quotidiano, ...",
+      },
+      {
+        id: "sanlai",
+        alias: "sanlai",
+        name: "Sanlai",
+        description: "Schiariture",
+        image: "/sanlai.webp",
+        imageAlt: "Schiariture Sanlai",
+        detailedDescription: "La tecnica Sanlai è il nostro metodo innovativo per schiarire i capelli ...",
+      },
+      {
+        id: "massaggio-del-cuoio-capelluto",
+        alias: "scalp-massage",
+        name: "Massaggio del Cuoio Capelluto",
+        description: "Rilassante massaggio per la salute dei capelli",
+        image: "/Massaggio.webp",
+        imageAlt: "Massaggio del Cuoio Capelluto",
+        detailedDescription: "Il nostro massaggio del cuoio capelluto non è solo rilassante, ma anche benefico ...",
+      },
+    ],
+  },
+  en: {
+    title: "Our Services",
+    services: [
+      {
+        id: "haircut",
+        alias: "taglio-di-capelli",
+        name: "Haircut",
+        description: "Personalized cut for men and women",
+        image: "/TaglioNew.jpg",
+        imageAlt: "Haircut",
+        detailedDescription: "Our haircut service offers a personalized experience ...",
+      },
+      {
+        id: "botanical-hair-coloring",
+        alias: "colorazione-con-erbe-botaniche",
+        name: "Botanical Hair Coloring",
+        description: "Natural dyes and innovative techniques",
+        image: "/ERBE.jpg",
+        imageAlt: "Botanical Hair Coloring",
+        detailedDescription: "Our botanical hair coloring is a gentle and natural treatment ...",
+      },
+      {
+        id: "treatments",
+        alias: "trattamenti",
+        name: "Treatments",
+        description: "Treatments for damaged hair and specific care",
+        image: "/trattamento.jpg",
+        imageAlt: "Treatments",
+        detailedDescription: `We offer a wide range of treatments for hair:
+- Plant-Based Keratin: ...
+- Herbal Scalp Treatments: ...
+- Peeling: ...
+- Revitalizing: ...
+- Post Color: ...
+- Deep Regeneration Treatment: ...`,
+      },
+      {
+        id: "hairstyling",
+        alias: "acconciature",
+        name: "Hairstyling",
+        description: "Styling for every occasion",
+        image: "/Acconciatura.jpg",
+        imageAlt: "Hairstyling",
+        detailedDescription: "Whether it's for a special occasion or an everyday look, ...",
+      },
+      {
+        id: "sanlai",
+        alias: "sanlai",
+        name: "Sanlai",
+        description: "Hair lightening",
+        image: "/sanlai.webp",
+        imageAlt: "Sanlai Hair Lightening",
+        detailedDescription: "The Sanlai technique is our innovative method for lightening hair ...",
+      },
+      {
+        id: "scalp-massage",
+        alias: "massaggio-del-cuoio-capelluto",
+        name: "Scalp Massage",
+        description: "Relaxing massage for hair health",
+        image: "/Massaggio.webp",
+        imageAlt: "Scalp Massage",
+        detailedDescription: "Our scalp massage is not only relaxing but also beneficial ...",
+      },
+    ],
+  },
+}
+
+export interface Product {
+  id: string
+  alias?: string
+  name: string
+  description: string
+  image: string
+  imageAlt: string
+  detailedDescription: string
+}
+
+export const productsTranslations: Record<Language, { title: string; products: Product[] }> = {
+  it: {
+    title: "I Nostri Prodotti",
+    products: [
+      {
+        id: "shampoo-riflessante-henne",
+        alias: "reflective-henna-shampoo",
+        name: "Shampoo Riflessante con Henné",
+        description: "Mantiene i riflessi naturali dei capelli trattati con henné.",
+        image: "/sh-hennè.webp",
+        imageAlt: "Shampoo Riflessante con Henné",
+        detailedDescription: "Formula riflessante per mantenere i toni spettacolari dell'hennè. Un prodotto unico formulato con puro estratto di hennè, ricco di zuccheri che ristrutturano la fibra capillare donando nuova vitalità. MODO D'USO A capello bagnato applicare il prodotto, massaggiare, lasciare agire per 4 minuti e procedere al risciacquo.PRINCIPI ATTIVILawsonia inermis leaves extract, Zuccheri.AZIONI Protegge e ristruttura in profondità la fibra capillare per dare elasticità e idratazione.PUNTI DI FORZALe erbe botaniche rappresentano uno dei prodotti base della fitocosmesi, ricavato dalle foglie essiccate e polverizzate di un arbusto (Lawsonia inermis) comunemente chiamato henna. La formula miscelata con estratti di erbe botaniche, rende il prodotto ottimale nel creare riflessi particolari, migliorando la lucentezza dei colori applicati e la morbidezza del capello. Le basi detergenti, dolci e delicate, consentono di utilizzare il prodotto su qualsiasi tipo di capello senza impoverirne il manto idrolipidico.INGREDIENTILawsonia inermis leaves extract, Sodium coceth sulfate, Cocamido propyl betaine, Cetrimonium chloride, Polyquaterniurn 10, Parfurn, Phenoxy ethanol, Sodiurn chloride. PARABENS FREE - SILICONES FREE",
+      },
+      {
+        id: "maschera-riflessante-henne",
+        alias: "reflective-henna-mask",
+        name: "Maschera Riflessante con Henné",
+        description: "Nutre e ravviva il colore naturalmente.",
+        image: "/mask-hennè.webp",
+        imageAlt: "Maschera Riflessante con Henné",
+        detailedDescription: "La Maschera riflessante con estratto di hennè è un trattamento intensivo che combina le proprietà nutrienti e ristrutturanti dell'hennè con una formula ricca di principi attivi. Il puro estratto di hennè, ricco di zuccheri naturali, penetra in profondità nella fibra capillare, riparandola e rinforzandola dall'interno. Questo trattamento non solo mantiene vivaci i riflessi, ma migliora anche la struttura del capello, lasciandolo più forte, elastico e luminoso.",
+      },
+      {
+        id: "Shampoo-Purificante-seboregolatore",
+        alias: "hair-oil",
+        name: "Shampoo Purificante-Seboregolatore",
+        description: "Azione riequilibrante per cute grassa o sensibile.",
+        image: "/sh-hennè.webp",
+        imageAlt: "Shampoo Purificante",
+        detailedDescription: "Il nostro Olio per Capelli è una formula leggera ma potente, studiata per nutrire in profondità i capelli senza appesantirli. Arricchito con oli naturali selezionati, questo prodotto aiuta a combattere il crespo, aumenta la lucentezza e protegge i capelli dai danni ambientali. Perfetto per tutti i tipi di capelli, può essere utilizzato sia come trattamento pre-shampoo che come finish per domare i capelli ribelli.",
+      },
+      {
+        id: "Bagnoschiuma-Purificante",
+        alias: "hydrating-bodywash",
+        name: "Bagnoschiuma Purificante",
+        description: "Sensazione di freschezza e pulizia profonda.",
+        image: "/sh-hennè.webp",
+        imageAlt: "Bagnoschiuma",
+        detailedDescription: "Azione antibatterica grazie all'estratto di liquirizia, bergamotto, ortica, cedro che dona alla pelle un'eccezionale sensazione di pulizia e freschezza. Azione calmante e lenitiva grazie all'utilizzo dell'acqua termale",
+      },
+      {
+        id: "Olio-lenitivo-olivo-e-girasole",
+        alias: "soothing-oil",
+        name: "Olio Lenitivo Olivo & Girasole",
+        description: "Idratazione intensa e naturale.",
+        image: "/sh-hennè.webp",
+        imageAlt: "Olio Lenitivo",
+        detailedDescription: "Formulato con puri oli di girasole e oliva, per un'idratazione emolliente intensa",
+      },
+    ],
+  },
+  en: {
+    title: "Our Products",
+    products: [
+      {
+        id: "reflective-henna-shampoo",
+        alias: "shampoo-riflessante-henne",
+        name: "Reflective Shampoo with Henna",
+        description: "Enhances and maintains henna-treated hair tones.",
+        image: "/sh-hennè.webp",
+        imageAlt: "Reflective Shampoo",
+        detailedDescription: "The Reflective Shampoo with henna extract has been specially formulated to maintain and enhance the reflections of henna-treated hair. Its gentle formula, enriched with natural extracts, not only gently cleanses the hair but also helps preserve the brilliance and intensity of the color. Ideal for frequent use, this shampoo nourishes and protects hair, leaving it soft, luminous, and with vibrant reflections.",
+      },
+      {
+        id: "reflective-henna-mask",
+        alias: "maschera-riflessante-henne",
+        name: "Reflective Mask with Henna",
+        description: "Deeply nourishes and enhances reflections.",
+        image: "/mask-hennè.webp",
+        imageAlt: "Reflective Mask",
+        detailedDescription: "The Reflective mask with henna extract is an intensive treatment that combines the nourishing and restructuring properties of henna with a formula rich in active ingredients. Pure henna extract, rich in natural sugars, penetrates deep into the hair fiber, repairing and strengthening it from within. This treatment not only keeps reflections vibrant but also improves hair structure, leaving it stronger, more elastic, and luminous.",
+      },
+      {
+        id: "hair-oil",
+        alias: "Shampoo-Purificante-seboregolatore",
+        name: "Purifying Shampoo",
+        description: "Sebum-balancing formula for a clean scalp.",
+        image: "/sh-hennè.webp",
+        imageAlt: "Purifying Shampoo",
+        detailedDescription: "Sebum-balancing formula for a clean scalp.",
+      },
+      {
+        id: "hydrating-bodywash",
+        alias: "Bagnoschiuma-Purificante",
+        name: "Purifying Bodywash",
+        description: "Deep cleansing and fresh sensation.",
+        image: "/sh-hennè.webp",
+        imageAlt: "Purifying Bodywash",
+        detailedDescription: "Deep cleansing and fresh sensation.",
+      },
+      {
+        id: "soothing-oil",
+        alias: "Olio-lenitivo-olivo-e-girasole",
+        name: "Soothing Oil - Olive & Sunflower",
+        description: "Moisturizing and softening treatment.",
+        image: "/sh-hennè.webp",
+        imageAlt: "Soothing Oil",
+        detailedDescription: "Moisturizing and softening treatment.",
+      },
+    ],
+  },
+}
+


### PR DESCRIPTION
## Summary
- add centralized translation module with Italian and English text
- import shared translations across pages and components
- deduplicate per-component translation objects

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5bdb7c05883339c4bf6c10bba0b0d